### PR TITLE
Update ShaderClass and have changable viewport color.

### DIFF
--- a/Gl_EditorFramework/GL_Core/GL_ControlBase.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlBase.cs
@@ -33,8 +33,6 @@ namespace GL_EditorFramework.GL_Core
 			
 		}
 
-		public Color ViewportColor = Color.FromArgb(20,20,20);
-
 		protected Matrix4 orientationCubeMtx;
 
 		protected bool showFakeCursor;
@@ -100,7 +98,9 @@ namespace GL_EditorFramework.GL_Core
 		private bool skipCameraAction;
 		private const int pickingIndexOffset = 7;
 
-		public AbstractCamera ActiveCamera
+        public Color ViewportColor = Color.FromArgb(20, 20, 20);
+
+        public AbstractCamera ActiveCamera
 		{
 			get => activeCamera;
 			set

--- a/Gl_EditorFramework/GL_Core/GL_ControlBase.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlBase.cs
@@ -33,6 +33,8 @@ namespace GL_EditorFramework.GL_Core
 			
 		}
 
+		public Color ViewportColor = Color.FromArgb(20,20,20);
+
 		protected Matrix4 orientationCubeMtx;
 
 		protected bool showFakeCursor;

--- a/Gl_EditorFramework/GL_Core/GL_ControlLegacy.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlLegacy.cs
@@ -14,280 +14,280 @@ using GL_EditorFramework.StandardCameras;
 
 namespace GL_EditorFramework.GL_Core
 {
-	public class GL_ControlLegacy : GL_ControlBase
-	{
-        public GL_ControlLegacy(int redrawerInterval) : base(1,redrawerInterval)
-		{
+    public class GL_ControlLegacy : GL_ControlBase
+    {
+        public GL_ControlLegacy(int redrawerInterval) : base(1, redrawerInterval)
+        {
 
-		}
+        }
 
-		public GL_ControlLegacy() : base(1, 16)
-		{
+        public GL_ControlLegacy() : base(1, 16)
+        {
 
-		}
+        }
 
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			if (DesignMode) return;
-			MakeCurrent();
-			Framework.Initialize();
-		}
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            if (DesignMode) return;
+            MakeCurrent();
+            Framework.Initialize();
+        }
 
-		public override AbstractGlDrawable MainDrawable
-		{
-			get => mainDrawable;
-			set
-			{
-				if (value == null || DesignMode) return;
-				mainDrawable = value;
-				MakeCurrent();
-				mainDrawable.Prepare(this);
-				Refresh();
-			}
-		}
+        public override AbstractGlDrawable MainDrawable
+        {
+            get => mainDrawable;
+            set
+            {
+                if (value == null || DesignMode) return;
+                mainDrawable = value;
+                MakeCurrent();
+                mainDrawable.Prepare(this);
+                Refresh();
+            }
+        }
 
-		public override void UpdateModelMatrix(Matrix4 matrix)
-		{
-			if (DesignMode) return;
-			mtxMdl = matrix;
-			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref mtxMdl);
-		}
+        public override void UpdateModelMatrix(Matrix4 matrix)
+        {
+            if (DesignMode) return;
+            mtxMdl = matrix;
+            GL.MatrixMode(MatrixMode.Modelview);
+            GL.LoadMatrix(ref mtxMdl);
+        }
 
-		public override void ApplyModelTransform(Matrix4 matrix)
-		{
-			if (DesignMode) return;
-			mtxMdl *= matrix;
-			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref mtxMdl);
-		}
+        public override void ApplyModelTransform(Matrix4 matrix)
+        {
+            if (DesignMode) return;
+            mtxMdl *= matrix;
+            GL.MatrixMode(MatrixMode.Modelview);
+            GL.LoadMatrix(ref mtxMdl);
+        }
 
-		public override void ResetModelMatrix()
-		{
-			if (DesignMode) return;
-			mtxMdl = Matrix4.Identity;
-			GL.MatrixMode(MatrixMode.Modelview);
-			GL.LoadMatrix(ref mtxMdl);
-		}
+        public override void ResetModelMatrix()
+        {
+            if (DesignMode) return;
+            mtxMdl = Matrix4.Identity;
+            GL.MatrixMode(MatrixMode.Modelview);
+            GL.LoadMatrix(ref mtxMdl);
+        }
 
-		protected override void OnPaint(PaintEventArgs e)
-		{
-			
-			if (mainDrawable == null || DesignMode)
-			{
-				e.Graphics.Clear(this.BackColor);
-				e.Graphics.DrawString("Legacy Gl" + (stereoscopy ? " stereoscopy" : ""), SystemFonts.DefaultFont, SystemBrushes.ControlLight, 10f, 10f);
-				return;
-			}
+        protected override void OnPaint(PaintEventArgs e)
+        {
 
-			MakeCurrent();
+            if (mainDrawable == null || DesignMode)
+            {
+                e.Graphics.Clear(this.BackColor);
+                e.Graphics.DrawString("Legacy Gl" + (stereoscopy ? " stereoscopy" : ""), SystemFonts.DefaultFont, SystemBrushes.ControlLight, 10f, 10f);
+                return;
+            }
 
-			GL.ClearColor(ViewportColor.R / 255.0f,
+            MakeCurrent();
+
+            GL.ClearColor(ViewportColor.R / 255.0f,
                           ViewportColor.G / 255.0f,
                           ViewportColor.B / 255.0f,
                           ViewportColor.A / 255.0f);
 
-			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-			if (stereoscopy)
-			{
-				#region left eye
-				GL.Viewport(0, 0, Width / 2, Height);
+            if (stereoscopy)
+            {
+                #region left eye
+                GL.Viewport(0, 0, Width / 2, Height);
 
-				ResetModelMatrix();
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(0.25f, 0, camDistance) *
-					Matrix4.CreateRotationY(0.02f);
+                ResetModelMatrix();
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(0.25f, 0, camDistance) *
+                    Matrix4.CreateRotationY(0.02f);
 
-				GL.MatrixMode(MatrixMode.Projection);
-				Matrix4 computedMatrix = mtxCam * mtxProj;
-				GL.LoadMatrix(ref computedMatrix);
+                GL.MatrixMode(MatrixMode.Projection);
+                Matrix4 computedMatrix = mtxCam * mtxProj;
+                GL.LoadMatrix(ref computedMatrix);
 
-				mainDrawable.Draw(this);
+                mainDrawable.Draw(this);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
-					Matrix4.CreateRotationY(0.03125f);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
+                    Matrix4.CreateRotationY(0.03125f);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-				DrawOrientationCube();
+                DrawOrientationCube();
 
-				if (showFakeCursor)
-				{
-					GL.Color3(1f, 1f, 1f);
-					GL.Disable(EnableCap.Texture2D);
-					GL.MatrixMode(MatrixMode.Projection);
-					GL.LoadIdentity();
-					ResetModelMatrix();
-					GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
-					GL.Scale(80f / Width, 40f / Height, 1);
-					GL.Begin(PrimitiveType.Polygon);
-					GL.Vertex2(0, 0);
-					GL.Vertex2(0.75, -0.25);
-					GL.Vertex2(0.375, -0.375);
-					GL.Vertex2(0.25, -0.875);
-					GL.End();
-					GL.Enable(EnableCap.Texture2D);
-				}
-				#endregion
+                if (showFakeCursor)
+                {
+                    GL.Color3(1f, 1f, 1f);
+                    GL.Disable(EnableCap.Texture2D);
+                    GL.MatrixMode(MatrixMode.Projection);
+                    GL.LoadIdentity();
+                    ResetModelMatrix();
+                    GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
+                    GL.Scale(80f / Width, 40f / Height, 1);
+                    GL.Begin(PrimitiveType.Polygon);
+                    GL.Vertex2(0, 0);
+                    GL.Vertex2(0.75, -0.25);
+                    GL.Vertex2(0.375, -0.375);
+                    GL.Vertex2(0.25, -0.875);
+                    GL.End();
+                    GL.Enable(EnableCap.Texture2D);
+                }
+                #endregion
 
-				#region right eye
-				GL.Viewport(Width / 2, 0, Width / 2, Height);
+                #region right eye
+                GL.Viewport(Width / 2, 0, Width / 2, Height);
 
-				ResetModelMatrix();
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(-0.25f, 0, camDistance) *
-					Matrix4.CreateRotationY(-0.02f);
+                ResetModelMatrix();
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(-0.25f, 0, camDistance) *
+                    Matrix4.CreateRotationY(-0.02f);
 
-				GL.MatrixMode(MatrixMode.Projection);
-				computedMatrix = mtxCam * mtxProj;
-				GL.LoadMatrix(ref computedMatrix);
-				mainDrawable.Draw(this);
+                GL.MatrixMode(MatrixMode.Projection);
+                computedMatrix = mtxCam * mtxProj;
+                GL.LoadMatrix(ref computedMatrix);
+                mainDrawable.Draw(this);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
-					Matrix4.CreateRotationY(-0.03125f);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
+                    Matrix4.CreateRotationY(-0.03125f);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-				DrawOrientationCube();
+                DrawOrientationCube();
 
-				if (showFakeCursor)
-				{
-					GL.Color3(1f, 1f, 1f);
-					GL.Disable(EnableCap.Texture2D);
-					GL.MatrixMode(MatrixMode.Projection);
-					GL.LoadIdentity();
-					ResetModelMatrix();
-					GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
-					GL.Scale(40f / ViewWidth, 40f / Height, 1);
-					GL.Begin(PrimitiveType.Polygon);
-					GL.Vertex2(0, 0);
-					GL.Vertex2(0.75, -0.25);
-					GL.Vertex2(0.375, -0.375);
-					GL.Vertex2(0.25, -0.875);
-					GL.End();
-					GL.Enable(EnableCap.Texture2D);
-				}
-				#endregion
-			}
-			else
-			{
-				GL.Viewport(0, 0, Width, Height);
+                if (showFakeCursor)
+                {
+                    GL.Color3(1f, 1f, 1f);
+                    GL.Disable(EnableCap.Texture2D);
+                    GL.MatrixMode(MatrixMode.Projection);
+                    GL.LoadIdentity();
+                    ResetModelMatrix();
+                    GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
+                    GL.Scale(40f / ViewWidth, 40f / Height, 1);
+                    GL.Begin(PrimitiveType.Polygon);
+                    GL.Vertex2(0, 0);
+                    GL.Vertex2(0.75, -0.25);
+                    GL.Vertex2(0.375, -0.375);
+                    GL.Vertex2(0.25, -0.875);
+                    GL.End();
+                    GL.Enable(EnableCap.Texture2D);
+                }
+                #endregion
+            }
+            else
+            {
+                GL.Viewport(0, 0, Width, Height);
 
-				ResetModelMatrix();
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(0, 0, camDistance);
+                ResetModelMatrix();
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(0, 0, camDistance);
 
-				GL.MatrixMode(MatrixMode.Projection);
-				Matrix4 computedMatrix = mtxCam * mtxProj;
-				GL.LoadMatrix(ref computedMatrix);
-				mainDrawable.Draw(this);
+                GL.MatrixMode(MatrixMode.Projection);
+                Matrix4 computedMatrix = mtxCam * mtxProj;
+                GL.LoadMatrix(ref computedMatrix);
+                mainDrawable.Draw(this);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(40f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 80f / Width, 1 - 80f / Height, 0);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(40f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 80f / Width, 1 - 80f / Height, 0);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-				DrawOrientationCube();
-			}
+                DrawOrientationCube();
+            }
 
-			SwapBuffers();
-			
-		}
+            SwapBuffers();
 
-		public override void DrawPicking()
-		{
-			if (DesignMode) return;
-			MakeCurrent();
-			GL.ClearColor(0f, 0f, 0f, 0f);
-			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+        }
 
-			if (stereoscopy)
-				GL.Viewport(0, 0, Width / 2, Height);
-			else
-				GL.Viewport(0, 0, Width, Height);
-			
-			ResetModelMatrix();
-			mtxCam =
-				Matrix4.CreateTranslation(camTarget) *
-				Matrix4.CreateRotationY(camRotX) *
-				Matrix4.CreateRotationX(camRotY) *
-				Matrix4.CreateTranslation(0, 0, camDistance);
+        public override void DrawPicking()
+        {
+            if (DesignMode) return;
+            MakeCurrent();
+            GL.ClearColor(0f, 0f, 0f, 0f);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-			GL.MatrixMode(MatrixMode.Projection);
-			Matrix4 computedMatrix = mtxCam * mtxProj;
-			GL.LoadMatrix(ref computedMatrix);
+            if (stereoscopy)
+                GL.Viewport(0, 0, Width / 2, Height);
+            else
+                GL.Viewport(0, 0, Width, Height);
 
-			skipPickingColors(6);
-			mainDrawable.DrawPicking(this);
+            ResetModelMatrix();
+            mtxCam =
+                Matrix4.CreateTranslation(camTarget) *
+                Matrix4.CreateRotationY(camRotX) *
+                Matrix4.CreateRotationX(camRotY) *
+                Matrix4.CreateTranslation(0, 0, camDistance);
 
-			GL.Disable(EnableCap.Texture2D);
-			GL.MatrixMode(MatrixMode.Projection);
-			GL.LoadIdentity();
-			GL.MatrixMode(MatrixMode.Modelview);
-			orientationCubeMtx =
-				Matrix4.CreateRotationY(camRotX) *
-				Matrix4.CreateRotationX(camRotY) *
-				Matrix4.CreateScale((stereoscopy?80f:40f) / Width, 40f / Height, 0.25f) *
-				Matrix4.CreateTranslation(1 - (stereoscopy ? 160f : 80f) / Width, 1 - 80f / Height, 0);
-			GL.LoadMatrix(ref orientationCubeMtx);
-			GL.Disable(EnableCap.DepthTest);
+            GL.MatrixMode(MatrixMode.Projection);
+            Matrix4 computedMatrix = mtxCam * mtxProj;
+            GL.LoadMatrix(ref computedMatrix);
 
-			GL.Begin(PrimitiveType.Quads);
-			GL.Color4(Color.FromArgb(1));
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Color4(Color.FromArgb(2));
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.Color4(Color.FromArgb(3));
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Color4(Color.FromArgb(4));
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Color4(Color.FromArgb(5));
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Color4(Color.FromArgb(6));
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.End();
-			GL.Enable(EnableCap.DepthTest);
-			GL.Enable(EnableCap.Texture2D);
-		}
-	}
+            skipPickingColors(6);
+            mainDrawable.DrawPicking(this);
+
+            GL.Disable(EnableCap.Texture2D);
+            GL.MatrixMode(MatrixMode.Projection);
+            GL.LoadIdentity();
+            GL.MatrixMode(MatrixMode.Modelview);
+            orientationCubeMtx =
+                Matrix4.CreateRotationY(camRotX) *
+                Matrix4.CreateRotationX(camRotY) *
+                Matrix4.CreateScale((stereoscopy ? 80f : 40f) / Width, 40f / Height, 0.25f) *
+                Matrix4.CreateTranslation(1 - (stereoscopy ? 160f : 80f) / Width, 1 - 80f / Height, 0);
+            GL.LoadMatrix(ref orientationCubeMtx);
+            GL.Disable(EnableCap.DepthTest);
+
+            GL.Begin(PrimitiveType.Quads);
+            GL.Color4(Color.FromArgb(1));
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Color4(Color.FromArgb(2));
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.Color4(Color.FromArgb(3));
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Color4(Color.FromArgb(4));
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Color4(Color.FromArgb(5));
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Color4(Color.FromArgb(6));
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.End();
+            GL.Enable(EnableCap.DepthTest);
+            GL.Enable(EnableCap.Texture2D);
+        }
+    }
 }

--- a/Gl_EditorFramework/GL_Core/GL_ControlLegacy.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlLegacy.cs
@@ -16,9 +16,7 @@ namespace GL_EditorFramework.GL_Core
 {
 	public class GL_ControlLegacy : GL_ControlBase
 	{
-		
-
-		public GL_ControlLegacy(int redrawerInterval) : base(1,redrawerInterval)
+        public GL_ControlLegacy(int redrawerInterval) : base(1,redrawerInterval)
 		{
 
 		}
@@ -85,7 +83,11 @@ namespace GL_EditorFramework.GL_Core
 
 			MakeCurrent();
 
-			GL.ClearColor(0.125f, 0.125f, 0.125f, 1.0f);
+			GL.ClearColor(ViewportColor.R / 255.0f,
+                          ViewportColor.G / 255.0f,
+                          ViewportColor.B / 255.0f,
+                          ViewportColor.A / 255.0f);
+
 			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
 			if (stereoscopy)

--- a/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
@@ -208,8 +208,6 @@ namespace GL_EditorFramework.GL_Core
                     GL.Enable(EnableCap.Texture2D);
                 }
                 #endregion
-
-
             }
             else
             {

--- a/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
@@ -14,295 +14,295 @@ using GL_EditorFramework.StandardCameras;
 
 namespace GL_EditorFramework.GL_Core
 {
-	public class GL_ControlModern : GL_ControlBase
-	{
-		public GL_ControlModern(int redrawerInterval) : base(3, redrawerInterval)
-		{
-			
-		}
+    public class GL_ControlModern : GL_ControlBase
+    {
+        public GL_ControlModern(int redrawerInterval) : base(3, redrawerInterval)
+        {
 
-		public GL_ControlModern() : base(3, 16)
-		{
+        }
 
-		}
+        public GL_ControlModern() : base(3, 16)
+        {
 
-		protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			if (DesignMode) return;
-			MakeCurrent();
-			Framework.Initialize();
-		}
+        }
 
-		private ShaderProgram shader;
-		public ShaderProgram CurrentShader
-		{
-			get => shader;
-			set
-			{
-				if (value == null || DesignMode) return;
-				shader = value;
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            if (DesignMode) return;
+            MakeCurrent();
+            Framework.Initialize();
+        }
 
-				shader.Setup(mtxMdl, mtxCam, mtxProj);
-			}
-		}
-		
-		public override AbstractGlDrawable MainDrawable
-		{
-			get => mainDrawable;
-			set
-			{
-				if (value == null || DesignMode) return;
-				mainDrawable = value;
-				MakeCurrent();
-				mainDrawable.Prepare(this);
-				Refresh();
-			}
-		}
-		
-		public override void UpdateModelMatrix(Matrix4 matrix)
-		{
-			if (DesignMode) return;
-			shader.UpdateModelMatrix(mtxMdl = matrix);
-		}
+        private ShaderProgram shader;
+        public ShaderProgram CurrentShader
+        {
+            get => shader;
+            set
+            {
+                if (value == null || DesignMode) return;
+                shader = value;
 
-		public override void ApplyModelTransform(Matrix4 matrix)
-		{
-			if (DesignMode) return;
-			shader.UpdateModelMatrix(mtxMdl *= matrix);
-		}
+                shader.Setup(mtxMdl, mtxCam, mtxProj);
+            }
+        }
 
-		public override void ResetModelMatrix()
-		{
-			if (DesignMode) return;
-			shader.UpdateModelMatrix(mtxMdl = Matrix4.Identity);
-		}
+        public override AbstractGlDrawable MainDrawable
+        {
+            get => mainDrawable;
+            set
+            {
+                if (value == null || DesignMode) return;
+                mainDrawable = value;
+                MakeCurrent();
+                mainDrawable.Prepare(this);
+                Refresh();
+            }
+        }
 
-		protected override void OnResize(EventArgs e)
-		{
-			if (DesignMode)
-			{
-				base.OnResize(e);
-				return;
-			}
-			MakeCurrent();
+        public override void UpdateModelMatrix(Matrix4 matrix)
+        {
+            if (DesignMode) return;
+            shader.UpdateModelMatrix(mtxMdl = matrix);
+        }
 
-			float aspect_ratio;
-			if (stereoscopy)
-				aspect_ratio = Width / 2 / (float)Height;
-			else
-				aspect_ratio = Width / (float)Height;
+        public override void ApplyModelTransform(Matrix4 matrix)
+        {
+            if (DesignMode) return;
+            shader.UpdateModelMatrix(mtxMdl *= matrix);
+        }
 
-			mtxProj = Matrix4.CreatePerspectiveFieldOfView(fov, aspect_ratio, znear, zfar);
+        public override void ResetModelMatrix()
+        {
+            if (DesignMode) return;
+            shader.UpdateModelMatrix(mtxMdl = Matrix4.Identity);
+        }
 
-			orientationCubeMtx = Matrix4.CreateOrthographic(Width, Height, 0.125f, 2f) * Matrix4.CreateTranslation(0,0,1);
+        protected override void OnResize(EventArgs e)
+        {
+            if (DesignMode)
+            {
+                base.OnResize(e);
+                return;
+            }
+            MakeCurrent();
 
-			//using the calculation from whitehole
-			factorX = (2f * (float)Math.Tan(fov * 0.5f) * aspect_ratio) / Width;
+            float aspect_ratio;
+            if (stereoscopy)
+                aspect_ratio = Width / 2 / (float)Height;
+            else
+                aspect_ratio = Width / (float)Height;
 
-			factorY = (2f * (float)Math.Tan(fov * 0.5f)) / Height;
+            mtxProj = Matrix4.CreatePerspectiveFieldOfView(fov, aspect_ratio, znear, zfar);
 
-			base.OnResize(e);
-		}
-		
-		protected override void OnPaint(PaintEventArgs e)
-		{
-			
-			if (mainDrawable == null || DesignMode)
-			{
-				base.OnPaint(e);
-				e.Graphics.Clear(Color.Black);
-				e.Graphics.DrawString("Modern Gl" + (stereoscopy ? " stereoscopy" : ""), SystemFonts.DefaultFont, SystemBrushes.ControlLight, 10f, 10f);
-				return;
-			}
-			MakeCurrent();
+            orientationCubeMtx = Matrix4.CreateOrthographic(Width, Height, 0.125f, 2f) * Matrix4.CreateTranslation(0, 0, 1);
 
-			base.OnPaint(e);
+            //using the calculation from whitehole
+            factorX = (2f * (float)Math.Tan(fov * 0.5f) * aspect_ratio) / Width;
 
-			GL.ClearColor(ViewportColor.R / 255.0f,
+            factorY = (2f * (float)Math.Tan(fov * 0.5f)) / Height;
+
+            base.OnResize(e);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+
+            if (mainDrawable == null || DesignMode)
+            {
+                base.OnPaint(e);
+                e.Graphics.Clear(Color.Black);
+                e.Graphics.DrawString("Modern Gl" + (stereoscopy ? " stereoscopy" : ""), SystemFonts.DefaultFont, SystemBrushes.ControlLight, 10f, 10f);
+                return;
+            }
+            MakeCurrent();
+
+            base.OnPaint(e);
+
+            GL.ClearColor(ViewportColor.R / 255.0f,
                           ViewportColor.G / 255.0f,
                           ViewportColor.B / 255.0f,
                           ViewportColor.A / 255.0f);
-						  
-			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-			if (stereoscopy)
-			{
-				#region left eye
-				GL.Viewport(0, 0, Width / 2, Height);
 
-				mtxMdl = Matrix4.Identity;
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(0.25f, 0, camDistance) *
-					Matrix4.CreateRotationY(0.02f);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+            if (stereoscopy)
+            {
+                #region left eye
+                GL.Viewport(0, 0, Width / 2, Height);
 
-				mainDrawable.Draw(this);
+                mtxMdl = Matrix4.Identity;
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(0.25f, 0, camDistance) *
+                    Matrix4.CreateRotationY(0.02f);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
-					Matrix4.CreateRotationY(0.03125f);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                mainDrawable.Draw(this);
 
-				DrawOrientationCube();
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
+                    Matrix4.CreateRotationY(0.03125f);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-				if (showFakeCursor)
-				{
-					GL.UseProgram(0);
-					GL.Disable(EnableCap.Texture2D);
-					GL.LoadIdentity();
-					GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
-					GL.Scale(80f / Width, 40f / Height, 1);
-					GL.Begin(PrimitiveType.Polygon);
-					GL.Vertex2(0, 0);
-					GL.Vertex2(0.75, -0.25);
-					GL.Vertex2(0.375, -0.375);
-					GL.Vertex2(0.25, -0.875);
-					GL.End();
-					GL.Enable(EnableCap.Texture2D);
-				}
-				#endregion
+                DrawOrientationCube();
 
-				#region right eye
-				GL.Viewport(Width / 2, 0, Width / 2, Height);
+                if (showFakeCursor)
+                {
+                    GL.UseProgram(0);
+                    GL.Disable(EnableCap.Texture2D);
+                    GL.LoadIdentity();
+                    GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
+                    GL.Scale(80f / Width, 40f / Height, 1);
+                    GL.Begin(PrimitiveType.Polygon);
+                    GL.Vertex2(0, 0);
+                    GL.Vertex2(0.75, -0.25);
+                    GL.Vertex2(0.375, -0.375);
+                    GL.Vertex2(0.25, -0.875);
+                    GL.End();
+                    GL.Enable(EnableCap.Texture2D);
+                }
+                #endregion
 
-				mtxMdl = Matrix4.Identity;
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(-0.25f, 0, camDistance) *
-					Matrix4.CreateRotationY(-0.02f);
+                #region right eye
+                GL.Viewport(Width / 2, 0, Width / 2, Height);
 
-				mainDrawable.Draw(this);
+                mtxMdl = Matrix4.Identity;
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(-0.25f, 0, camDistance) *
+                    Matrix4.CreateRotationY(-0.02f);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
-					Matrix4.CreateRotationY(-0.03125f);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                mainDrawable.Draw(this);
 
-				DrawOrientationCube();
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(80f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 160f / Width, 1 - 80f / Height, 0) *
+                    Matrix4.CreateRotationY(-0.03125f);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-				if (showFakeCursor)
-				{
-					GL.UseProgram(0);
-					GL.Disable(EnableCap.Texture2D);
-					GL.LoadIdentity();
-					GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
-					GL.Scale(40f / ViewWidth, 40f / Height, 1);
-					GL.Begin(PrimitiveType.Polygon);
-					GL.Vertex2(0, 0);
-					GL.Vertex2(0.75, -0.25);
-					GL.Vertex2(0.375, -0.375);
-					GL.Vertex2(0.25, -0.875);
-					GL.End();
-					GL.Enable(EnableCap.Texture2D);
-				}
-				#endregion
+                DrawOrientationCube();
+
+                if (showFakeCursor)
+                {
+                    GL.UseProgram(0);
+                    GL.Disable(EnableCap.Texture2D);
+                    GL.LoadIdentity();
+                    GL.Translate(lastMouseLoc.X * 2 / (float)Width - 1, -(lastMouseLoc.Y * 2 / (float)Height - 1), 0);
+                    GL.Scale(40f / ViewWidth, 40f / Height, 1);
+                    GL.Begin(PrimitiveType.Polygon);
+                    GL.Vertex2(0, 0);
+                    GL.Vertex2(0.75, -0.25);
+                    GL.Vertex2(0.375, -0.375);
+                    GL.Vertex2(0.25, -0.875);
+                    GL.End();
+                    GL.Enable(EnableCap.Texture2D);
+                }
+                #endregion
 
 
-			}
-			else
-			{
-				GL.Viewport(0, 0, Width, Height);
-				
-				mtxMdl = Matrix4.Identity;
-				mtxCam =
-					Matrix4.CreateTranslation(camTarget) *
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateTranslation(0, 0, camDistance);
+            }
+            else
+            {
+                GL.Viewport(0, 0, Width, Height);
 
-				mainDrawable.Draw(this);
+                mtxMdl = Matrix4.Identity;
+                mtxCam =
+                    Matrix4.CreateTranslation(camTarget) *
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateTranslation(0, 0, camDistance);
 
-				GL.MatrixMode(MatrixMode.Modelview);
-				orientationCubeMtx =
-					Matrix4.CreateRotationY(camRotX) *
-					Matrix4.CreateRotationX(camRotY) *
-					Matrix4.CreateScale(40f / Width, 40f / Height, 0.25f) *
-					Matrix4.CreateTranslation(1 - 80f / Width, 1 - 80f / Height, 0);
-				GL.LoadMatrix(ref orientationCubeMtx);
+                mainDrawable.Draw(this);
 
-				DrawOrientationCube();
-			}
-			SwapBuffers();
+                GL.MatrixMode(MatrixMode.Modelview);
+                orientationCubeMtx =
+                    Matrix4.CreateRotationY(camRotX) *
+                    Matrix4.CreateRotationX(camRotY) *
+                    Matrix4.CreateScale(40f / Width, 40f / Height, 0.25f) *
+                    Matrix4.CreateTranslation(1 - 80f / Width, 1 - 80f / Height, 0);
+                GL.LoadMatrix(ref orientationCubeMtx);
 
-			GL.UseProgram(0);
-			
-		}
+                DrawOrientationCube();
+            }
+            SwapBuffers();
 
-		public override void DrawPicking()
-		{
-			if (DesignMode) return;
-			MakeCurrent();
-			GL.ClearColor(0f, 0f, 0f, 0f);
-			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+            GL.UseProgram(0);
 
-			if (stereoscopy)
-				GL.Viewport(0, 0, Width / 2, Height);
-			else
-				GL.Viewport(0, 0, Width, Height);
+        }
 
-			skipPickingColors(6);
-			mainDrawable.DrawPicking(this);
+        public override void DrawPicking()
+        {
+            if (DesignMode) return;
+            MakeCurrent();
+            GL.ClearColor(0f, 0f, 0f, 0f);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-			GL.UseProgram(0);
-			GL.Disable(EnableCap.Texture2D);
-			GL.MatrixMode(MatrixMode.Projection);
-			GL.LoadIdentity();
-			GL.MatrixMode(MatrixMode.Modelview);
-			orientationCubeMtx =
-				Matrix4.CreateRotationY(camRotX) *
-				Matrix4.CreateRotationX(camRotY) *
-				Matrix4.CreateScale(stereoscopy ? 80f : 40f / Width, 40f / Height, 0.25f) *
-				Matrix4.CreateTranslation(1 - (stereoscopy ? 160f : 80f) / Width, 1 - 80f / Height, 0);
-			GL.LoadMatrix(ref orientationCubeMtx);
-			GL.Disable(EnableCap.DepthTest);
-			
-			GL.Begin(PrimitiveType.Quads);
-			GL.Color4(Color.FromArgb(1));
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Color4(Color.FromArgb(2));
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.Color4(Color.FromArgb(3));
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Color4(Color.FromArgb(4));
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Color4(Color.FromArgb(5));
-			GL.Vertex3(1f, 1f, 1f);
-			GL.Vertex3(1f, 1f, -1f);
-			GL.Vertex3(1f, -1f, -1f);
-			GL.Vertex3(1f, -1f, 1f);
-			GL.Color4(Color.FromArgb(6));
-			GL.Vertex3(-1f, 1f, -1f);
-			GL.Vertex3(-1f, 1f, 1f);
-			GL.Vertex3(-1f, -1f, 1f);
-			GL.Vertex3(-1f, -1f, -1f);
-			GL.End();
-			GL.Enable(EnableCap.DepthTest);
-			GL.Enable(EnableCap.Texture2D);
-		}
-		
-	}
+            if (stereoscopy)
+                GL.Viewport(0, 0, Width / 2, Height);
+            else
+                GL.Viewport(0, 0, Width, Height);
+
+            skipPickingColors(6);
+            mainDrawable.DrawPicking(this);
+
+            GL.UseProgram(0);
+            GL.Disable(EnableCap.Texture2D);
+            GL.MatrixMode(MatrixMode.Projection);
+            GL.LoadIdentity();
+            GL.MatrixMode(MatrixMode.Modelview);
+            orientationCubeMtx =
+                Matrix4.CreateRotationY(camRotX) *
+                Matrix4.CreateRotationX(camRotY) *
+                Matrix4.CreateScale(stereoscopy ? 80f : 40f / Width, 40f / Height, 0.25f) *
+                Matrix4.CreateTranslation(1 - (stereoscopy ? 160f : 80f) / Width, 1 - 80f / Height, 0);
+            GL.LoadMatrix(ref orientationCubeMtx);
+            GL.Disable(EnableCap.DepthTest);
+
+            GL.Begin(PrimitiveType.Quads);
+            GL.Color4(Color.FromArgb(1));
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Color4(Color.FromArgb(2));
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.Color4(Color.FromArgb(3));
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Color4(Color.FromArgb(4));
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Color4(Color.FromArgb(5));
+            GL.Vertex3(1f, 1f, 1f);
+            GL.Vertex3(1f, 1f, -1f);
+            GL.Vertex3(1f, -1f, -1f);
+            GL.Vertex3(1f, -1f, 1f);
+            GL.Color4(Color.FromArgb(6));
+            GL.Vertex3(-1f, 1f, -1f);
+            GL.Vertex3(-1f, 1f, 1f);
+            GL.Vertex3(-1f, -1f, 1f);
+            GL.Vertex3(-1f, -1f, -1f);
+            GL.End();
+            GL.Enable(EnableCap.DepthTest);
+            GL.Enable(EnableCap.Texture2D);
+        }
+
+    }
 }

--- a/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
+++ b/Gl_EditorFramework/GL_Core/GL_ControlModern.cs
@@ -119,7 +119,11 @@ namespace GL_EditorFramework.GL_Core
 
 			base.OnPaint(e);
 
-			GL.ClearColor(0.125f, 0.125f, 0.125f, 1.0f);
+			GL.ClearColor(ViewportColor.R / 255.0f,
+                          ViewportColor.G / 255.0f,
+                          ViewportColor.B / 255.0f,
+                          ViewportColor.A / 255.0f);
+						  
 			GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 			if (stereoscopy)
 			{

--- a/Gl_EditorFramework/GL_Core/ShaderClass.cs
+++ b/Gl_EditorFramework/GL_Core/ShaderClass.cs
@@ -10,32 +10,56 @@ namespace GL_EditorFramework.GL_Core
 {
     public class ShaderProgram
     {
-        private int fragSh, vertSh, program;
+        private int fragSh, vertSh, geomSh;
         private Matrix4 modelMatrix;
         private Matrix4 computedCamMtx;
         private Dictionary<string, int> attributes = new Dictionary<string, int>();
         private int activeAttributeCount;
+        public int program;
 
         public ShaderProgram(FragmentShader frag, VertexShader vert)
         {
-            fragSh = frag.shader;
-            vertSh = vert.shader;
-            program = GL.CreateProgram();
-            GL.AttachShader(program, vertSh);
-            GL.AttachShader(program, fragSh);
-            GL.LinkProgram(program);
-            Console.WriteLine("fragment:");
-            Console.WriteLine(GL.GetShaderInfoLog(fragSh));
-            Console.WriteLine("vertex:");
-            Console.WriteLine(GL.GetShaderInfoLog(vertSh));
+            LoadShaders(new Shader[] { vert, frag });
+        }
 
+        public ShaderProgram(FragmentShader frag, VertexShader vert, GeomertyShader geom)
+        {
+            LoadShaders(new Shader[] { vert, frag, geom });
+        }
+
+        public ShaderProgram(Shader[] shaders)
+        {
+            LoadShaders(shaders);
+        }
+
+        private void LoadShaders(Shader[] shaders)
+        {
+            program = GL.CreateProgram();
+
+            foreach (Shader shader in shaders)
+            {
+                AttachShader(shader);
+            }
+
+            GL.LinkProgram(program);
+            foreach (Shader shader in shaders)
+            {
+                if (shader.type == ShaderType.VertexShader)
+                    Console.WriteLine("vertex:");
+                if (shader.type == ShaderType.FragmentShader)
+                    Console.WriteLine("fragment:");
+                if (shader.type == ShaderType.GeometryShader)
+                    Console.WriteLine("geometry:");
+
+                Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
+            }
             LoadAttributes();
         }
 
         public void AttachShader(Shader shader)
         {
-            Console.WriteLine("shader:");
-            Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
+            //Console.WriteLine("shader:");
+            //Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
             GL.AttachShader(program, shader.shader);
         }
 
@@ -143,12 +167,42 @@ namespace GL_EditorFramework.GL_Core
             }
         }
 
-        public void UniformBoolToInt(string name, bool value)
+        public void SetBoolToInt(string name, bool value)
         {
             if (value)
                 GL.Uniform1(this[name], 1);
             else
                 GL.Uniform1(this[name], 0);
+        }
+
+        public void SetMatrix4x4(string name, ref Matrix4 value, bool Transpose = false)
+        {
+            GL.UniformMatrix4(this["mvpMatrix"], false, ref value);
+        }
+
+        public void SetVector4(string name, Vector4 value)
+        {
+            GL.Uniform4(this[name], value);
+        }
+
+        public void SetVector3(string name, Vector3 value)
+        {
+            GL.Uniform3(this[name], value);
+        }
+
+        public void SetVector2(string name, Vector2 value)
+        {
+            GL.Uniform2(this[name], value);
+        }
+
+        public void SetFloat(string name, float value)
+        {
+            GL.Uniform1(this[name], value);
+        }
+
+        public void SetInt(string name, int value)
+        {
+            GL.Uniform1(this[name], value);
         }
     }
 
@@ -180,6 +234,15 @@ namespace GL_EditorFramework.GL_Core
     {
         public VertexShader(string src)
             : base(src, ShaderType.VertexShader)
+        {
+
+        }
+    }
+
+    public class GeomertyShader : Shader
+    {
+        public GeomertyShader(string src)
+            : base(src, ShaderType.GeometryShader)
         {
 
         }

--- a/Gl_EditorFramework/GL_Core/ShaderClass.cs
+++ b/Gl_EditorFramework/GL_Core/ShaderClass.cs
@@ -8,8 +8,8 @@ using OpenTK.Graphics.OpenGL;
 
 namespace GL_EditorFramework.GL_Core
 {
-	public class ShaderProgram
-	{
+    public class ShaderProgram
+    {
         private int fragSh, vertSh, program;
         private Matrix4 modelMatrix;
         private Matrix4 computedCamMtx;
@@ -33,72 +33,73 @@ namespace GL_EditorFramework.GL_Core
         }
 
         public void AttachShader(Shader shader)
-		{
-			Console.WriteLine("shader:");
-			Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
-			GL.AttachShader(program, shader.shader);
+        {
+            Console.WriteLine("shader:");
+            Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
+            GL.AttachShader(program, shader.shader);
         }
 
         public void DetachShader(Shader shader)
-		{
-			GL.DetachShader(program, shader.shader);
-		}
-
-		public void LinkShaders()
-		{
-			GL.LinkProgram(program);
+        {
+            GL.DetachShader(program, shader.shader);
         }
 
-		public void SetFragmentShader(FragmentShader shader)
-		{
-			GL.DetachShader(program, fragSh);
-			GL.AttachShader(program, shader.shader);
-			fragSh = shader.shader;
-			GL.LinkProgram(program);
-		}
+        public void LinkShaders()
+        {
+            GL.LinkProgram(program);
+        }
 
-		public void SetVertexShader(VertexShader shader)
-		{
-			GL.DetachShader(program, vertSh);
-			GL.AttachShader(program, shader.shader);
-			vertSh = shader.shader;
-			GL.LinkProgram(program);
+        public void SetFragmentShader(FragmentShader shader)
+        {
+            GL.DetachShader(program, fragSh);
+            GL.AttachShader(program, shader.shader);
+            fragSh = shader.shader;
+            GL.LinkProgram(program);
+        }
 
-			GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxMdl"), false, ref modelMatrix);
-			GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxCam"), false, ref computedCamMtx);
-		}
+        public void SetVertexShader(VertexShader shader)
+        {
+            GL.DetachShader(program, vertSh);
+            GL.AttachShader(program, shader.shader);
+            vertSh = shader.shader;
+            GL.LinkProgram(program);
 
-		public void Setup(Matrix4 mtxMdl, Matrix4 mtxCam, Matrix4 mtxProj)
-		{
-			GL.UseProgram(program);
-			modelMatrix = mtxMdl;
-			int mtxMdl_loc = GL.GetUniformLocation(program, "mtxMdl");
-			if(mtxMdl_loc!=-1)
-				GL.UniformMatrix4(mtxMdl_loc, false, ref modelMatrix);
+            GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxMdl"), false, ref modelMatrix);
+            GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxCam"), false, ref computedCamMtx);
+        }
 
-			computedCamMtx = mtxCam * mtxProj;
+        public void Setup(Matrix4 mtxMdl, Matrix4 mtxCam, Matrix4 mtxProj)
+        {
+            GL.UseProgram(program);
+            modelMatrix = mtxMdl;
+            int mtxMdl_loc = GL.GetUniformLocation(program, "mtxMdl");
+            if (mtxMdl_loc != -1)
+                GL.UniformMatrix4(mtxMdl_loc, false, ref modelMatrix);
 
-			int mtxCam_loc = GL.GetUniformLocation(program, "mtxCam");
-			if (mtxCam_loc != -1)
-				GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxCam"), false, ref computedCamMtx);
-		}
+            computedCamMtx = mtxCam * mtxProj;
 
-		public void UpdateModelMatrix(Matrix4 matrix)
-		{
-			modelMatrix = matrix;
-			int mtxMdl_loc = GL.GetUniformLocation(program, "mtxMdl");
-			if (mtxMdl_loc != -1)
-				GL.UniformMatrix4(mtxMdl_loc, false, ref modelMatrix);
-		}
+            int mtxCam_loc = GL.GetUniformLocation(program, "mtxCam");
+            if (mtxCam_loc != -1)
+                GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxCam"), false, ref computedCamMtx);
+        }
 
-		public void Activate()
-		{
-			GL.UseProgram(program);
-		}
+        public void UpdateModelMatrix(Matrix4 matrix)
+        {
+            modelMatrix = matrix;
+            int mtxMdl_loc = GL.GetUniformLocation(program, "mtxMdl");
+            if (mtxMdl_loc != -1)
+                GL.UniformMatrix4(mtxMdl_loc, false, ref modelMatrix);
+        }
 
-		public int this[string name]{
-			get => GL.GetUniformLocation(program, name);
-		}
+        public void Activate()
+        {
+            GL.UseProgram(program);
+        }
+
+        public int this[string name]
+        {
+            get => GL.GetUniformLocation(program, name);
+        }
 
         private void LoadAttributes()
         {
@@ -151,36 +152,36 @@ namespace GL_EditorFramework.GL_Core
         }
     }
 
-	public class Shader
-	{
-		public Shader(string src, ShaderType type)
-		{
-			shader = GL.CreateShader(type);
-			GL.ShaderSource(shader, src);
-			GL.CompileShader(shader);
-			this.type = type;
-		}
+    public class Shader
+    {
+        public Shader(string src, ShaderType type)
+        {
+            shader = GL.CreateShader(type);
+            GL.ShaderSource(shader, src);
+            GL.CompileShader(shader);
+            this.type = type;
+        }
 
-		public ShaderType type;
+        public ShaderType type;
 
-		public int shader;
-	}
+        public int shader;
+    }
 
-	public class FragmentShader : Shader
-	{
-		public FragmentShader(string src)
-			:base(src, ShaderType.FragmentShader)
-		{
+    public class FragmentShader : Shader
+    {
+        public FragmentShader(string src)
+            : base(src, ShaderType.FragmentShader)
+        {
 
-		}
-	}
+        }
+    }
 
-	public class VertexShader : Shader
-	{
-		public VertexShader(string src)
-			: base(src, ShaderType.VertexShader)
-		{
+    public class VertexShader : Shader
+    {
+        public VertexShader(string src)
+            : base(src, ShaderType.VertexShader)
+        {
 
-		}
-	}
+        }
+    }
 }

--- a/Gl_EditorFramework/GL_Core/ShaderClass.cs
+++ b/Gl_EditorFramework/GL_Core/ShaderClass.cs
@@ -50,22 +50,22 @@ namespace GL_EditorFramework.GL_Core
                     Console.WriteLine("fragment:");
                 if (shader.type == ShaderType.GeometryShader)
                     Console.WriteLine("geometry:");
-
-                Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
+                    
+                Console.WriteLine(GL.GetShaderInfoLog(shader.id));
             }
             LoadAttributes();
         }
 
         public void AttachShader(Shader shader)
         {
-            //Console.WriteLine("shader:");
-            //Console.WriteLine(GL.GetShaderInfoLog(shader.shader));
-            GL.AttachShader(program, shader.shader);
+            Console.WriteLine("shader:");
+            Console.WriteLine(GL.GetShaderInfoLog(shader.id));
+            GL.AttachShader(program, shader.id);
         }
 
         public void DetachShader(Shader shader)
         {
-            GL.DetachShader(program, shader.shader);
+            GL.DetachShader(program, shader.id);
         }
 
         public void LinkShaders()
@@ -76,16 +76,16 @@ namespace GL_EditorFramework.GL_Core
         public void SetFragmentShader(FragmentShader shader)
         {
             GL.DetachShader(program, fragSh);
-            GL.AttachShader(program, shader.shader);
-            fragSh = shader.shader;
+            GL.AttachShader(program, shader.id);
+            fragSh = shader.id;
             GL.LinkProgram(program);
         }
 
         public void SetVertexShader(VertexShader shader)
         {
             GL.DetachShader(program, vertSh);
-            GL.AttachShader(program, shader.shader);
-            vertSh = shader.shader;
+            GL.AttachShader(program, shader.id);
+            vertSh = shader.id;
             GL.LinkProgram(program);
 
             GL.UniformMatrix4(GL.GetUniformLocation(program, "mtxMdl"), false, ref modelMatrix);
@@ -210,15 +210,15 @@ namespace GL_EditorFramework.GL_Core
     {
         public Shader(string src, ShaderType type)
         {
-            shader = GL.CreateShader(type);
-            GL.ShaderSource(shader, src);
-            GL.CompileShader(shader);
+            id = GL.CreateShader(type);
+            GL.ShaderSource(id, src);
+            GL.CompileShader(id);
             this.type = type;
         }
 
         public ShaderType type;
 
-        public int shader;
+        public int id;
     }
 
     public class FragmentShader : Shader

--- a/Gl_EditorFramework/GL_Core/ShaderClass.cs
+++ b/Gl_EditorFramework/GL_Core/ShaderClass.cs
@@ -10,24 +10,24 @@ namespace GL_EditorFramework.GL_Core
 {
 	public class ShaderProgram
 	{
-		private int fragSh, vertSh, program;
-		private Matrix4 modelMatrix;
-		private Matrix4 computedCamMtx;
+        private int fragSh, vertSh, program;
+        private Matrix4 modelMatrix;
+        private Matrix4 computedCamMtx;
         private Dictionary<string, int> attributes = new Dictionary<string, int>();
         private int activeAttributeCount;
 
         public ShaderProgram(FragmentShader frag, VertexShader vert)
-		{
-			fragSh = frag.shader;
-			vertSh = vert.shader;
-			program = GL.CreateProgram();
-			GL.AttachShader(program, vertSh);
-			GL.AttachShader(program, fragSh);
-			GL.LinkProgram(program);
-			Console.WriteLine("fragment:");
-			Console.WriteLine(GL.GetShaderInfoLog(fragSh));
-			Console.WriteLine("vertex:");
-			Console.WriteLine(GL.GetShaderInfoLog(vertSh));
+        {
+            fragSh = frag.shader;
+            vertSh = vert.shader;
+            program = GL.CreateProgram();
+            GL.AttachShader(program, vertSh);
+            GL.AttachShader(program, fragSh);
+            GL.LinkProgram(program);
+            Console.WriteLine("fragment:");
+            Console.WriteLine(GL.GetShaderInfoLog(fragSh));
+            Console.WriteLine("vertex:");
+            Console.WriteLine(GL.GetShaderInfoLog(vertSh));
 
             LoadAttributes();
         }

--- a/Gl_EditorFramework/Gl_EditorFramework.csproj
+++ b/Gl_EditorFramework/Gl_EditorFramework.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK">
-      <HintPath>..\packages\OpenTK.3.0.1\lib\net20\OpenTK.dll</HintPath>
+      <HintPath>..\..\..\Switch_Toolbox\Switch-Toolbox\Switch_Toolbox\Lib\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.GLControl">
-      <HintPath>..\packages\OpenTK.GLControl.3.0.1\lib\net20\OpenTK.GLControl.dll</HintPath>
+      <HintPath>..\..\..\Switch_Toolbox\Switch-Toolbox\Switch_Toolbox\Lib\OpenTK.GLControl.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Gl_EditorFramework/Gl_EditorFramework.csproj
+++ b/Gl_EditorFramework/Gl_EditorFramework.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK">
-      <HintPath>..\..\..\Switch_Toolbox\Switch-Toolbox\Switch_Toolbox\Lib\OpenTK.dll</HintPath>
+      <HintPath>..\packages\OpenTK.3.0.1\lib\net20\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK.GLControl">
-      <HintPath>..\..\..\Switch_Toolbox\Switch-Toolbox\Switch_Toolbox\Lib\OpenTK.GLControl.dll</HintPath>
+      <HintPath>..\packages\OpenTK.GLControl.3.0.1\lib\net20\OpenTK.GLControl.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
For the ShaderClass
 - Shaders can be loaded in an array. This is to support multiple fragment, vertex, or geometry shaders in one ShaderProgram. 
- Support geometry shader type. 
- Add setters to easily set data to the shader. Based on what Smash Forge had used, which made things alot easier.
- Attributes are loadable with GetAttribute(), which are enabled with EnableVertexAttributes() or diabled with DisableVertexAttributes();
